### PR TITLE
add pyproject toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vtt2clean_srt"
+version = "2022.02.12"
+dependencies = [
+  "webvtt-py",
+]
+requires-python = ">=3.8"
+authors = [
+  {name = "shironoY"},
+]
+maintainers = [
+]
+description = "convert vtt to srt subtitles without duplicate lines"
+readme = "README.md"
+license = {file = "LICENSE"}
+keywords = ["vtt2srt", "subtitles", "subtitles-converter"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python"
+]
+
+[project.urls]
+Homepage = "https://github.com/shironoY6/vtt2clean_srt"
+
+[project.scripts]
+vtt2clean_srt = "vtt2clean_srt:main"

--- a/vtt2clean_srt.py
+++ b/vtt2clean_srt.py
@@ -25,7 +25,7 @@ To extract only the text parts:
 '''
 
 
-if __name__ == '__main__':
+def main():
 
     # setting up parameters
     vtt_file = sys.argv[1]   # vtt file to convert
@@ -58,3 +58,8 @@ if __name__ == '__main__':
 
     if only_text:
         print(transcript)
+
+
+if __name__ == '__main__':
+
+    main()


### PR DESCRIPTION
pyproject.toml is needed for packaging
for example in [vtt2clean-srt.nix](https://github.com/milahu/nur-packages/raw/master/pkgs/python3/pkgs/vtt2clean-srt/default.nix)

```
$ nix-shell -p nur.repos.milahu.vtt2clean-srt
$ vtt2clean_srt src.vtt > dst.srt
```

also change description

```diff
-Clean and convert vtt to srt
+convert vtt to srt subtitles without duplicate lines
```

... because thats what i would type into a search engine